### PR TITLE
Don't invoke .ready() callback twice if it throws

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ Blake2b.ready = function (cb) {
     rdy = WebAssembly.instantiate(buf).then(setup)
   }
 
-  return rdy.then(cb).catch(cb)
+  return rdy.then(cb, cb)
 }
 
 function noop () {}

--- a/test.js
+++ b/test.js
@@ -2,7 +2,15 @@ var tape = require('tape')
 var blake2b = require('./')
 var vectors = require('blake2b/test-vectors.json')
 
+var readyCalled = false
+process.on('exit', function () {
+  if (!readyCalled)
+    throw new Error('ready not called')
+})
+
 blake2b.ready(function () {
+  readyCalled = true
+
   tape('hello world', function (t) {
     var hash = blake2b()
       .update(Buffer.from('hello'))

--- a/test.js
+++ b/test.js
@@ -70,3 +70,16 @@ blake2b.ready(function () {
     })
   })
 })
+
+tape('.ready()', function (t) {
+  var invokeCount = 0;
+  blake2b
+    .ready(function () {
+      invokeCount++
+      throw new Error()
+    })
+    .catch(function () {
+      t.same(invokeCount, 1)
+      t.end()
+    })
+});


### PR DESCRIPTION
Previously, when the callback passed to `.ready()` would throw, it would be called again because it was also registered as a `.catch()` handler for the same Promise that invoked it.

@mafintosh 