### PR TITLE
Use `Buffer.from()` instead of `new Buffer`

### DIFF
--- a/blake2b.js
+++ b/blake2b.js
@@ -53,7 +53,7 @@ function loadWebAssembly (opts) {
 
 function toUint8Array (s) {
   if (typeof atob === 'function') return new Uint8Array(atob(s).split('').map(charCodeAt))
-  return new (require('buf' + 'fer').Buffer)(s, 'base64')
+  return (require('buf' + 'fer').Buffer).from(s, 'base64')
 }
 
 function charCodeAt (c) {

--- a/example.js
+++ b/example.js
@@ -1,10 +1,11 @@
+'use strict'
 var blake2b = require('./')
 
 blake2b.ready(function () {
   var hash = blake2b()
-    .update(new Buffer('hello'))
-    .update(new Buffer(' '))
-    .update(new Buffer('world'))
+    .update(Buffer.from('hello'))
+    .update(Buffer.from(' '))
+    .update(Buffer.from('world'))
     .digest('hex')
 
   console.log('Blake2b hash of "hello world" is %s', hash)


### PR DESCRIPTION
The `Buffer` constructor is deprecated, we should
use `Buffer.from()` instead.

Refs: https://github.com/nodejs/node/issues/19079