### PR TITLE
Add input size check to update() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Create a new hash instance. `digestLength` defaults to `32`.
 
 Update the hash with a new piece of data. `data` should be a buffer or uint8array.
 
+The size of the data is limited to `65536000 - 64 - 216*n` bytes, where `n` is the number of Blake2b instances.
+
 #### `var digest = hash.digest([enc])`
 
 Digest the hash.

--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ Blake2b.prototype._realloc = function (size) {
 Blake2b.prototype.update = function (input) {
   assert(this.finalized === false, 'Hash instance finalized')
   assert(input instanceof Uint8Array, 'input must be Uint8Array or Buffer')
+  assert(input.length + head <= 65536000, 'input + head must be of size 65,536,000 or less')
 
   if (head + input.length > this._memory.length) this._realloc(head + input.length)
   this._memory.set(input, head)


### PR DESCRIPTION
In response to #18.

Add a check on the input size of the `Blake2b.prototope.update()` method.

https://github.com/mafintosh/blake2b-wasm/blob/0359a9be5a3bbe2e11bbb51fe485789b47bbf93c/index.js#L82

## Reason

The WebAssembly instance memory is limited to 65,536,000 bytes (64 * 1,000 KiB) because of the following:

https://github.com/mafintosh/blake2b-wasm/blob/7d8efa4f71d71983bc87983b25c6c9513fb9d1a0/blake2b.wat#L3

Therefore, the memory can only grow to this size, and the `update()` method fails when `input.length + head > 65536000`.