### PR TITLE
Upgrading wasm-tools to its latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "blake2b": "^1.2.0",
     "browserify": "^14.4.0",
     "tape": "^4.6.3",
-    "wasm-tools": "^0.2.0"
+    "wasm-tools": "^0.2.1"
   },
   "scripts": {
     "compile": "wasm-to-js -f cjs blake2b.wat > blake2b.js",


### PR DESCRIPTION
This PR upgrades wasm-tools to its latest version, where esbuild supports more system architectures.